### PR TITLE
fix: resolve optional file field validation issue

### DIFF
--- a/mantlz-sdk/src/components/form/hooks/useFormLogic.ts
+++ b/mantlz-sdk/src/components/form/hooks/useFormLogic.ts
@@ -86,22 +86,25 @@ export const useFormLogic = (
           validator = z.string().email(); 
           break;
         case 'file': 
-          validator = z.instanceof(File).optional(); 
+          // Handle file validation based on required status
+          if (field.required) {
+            validator = z.instanceof(File, { message: `${field.label || 'File'} is required` });
+          } else {
+            validator = z.instanceof(File).optional();
+          }
           break;
         default: 
           validator = z.string(); 
           break;
       }
 
-      if (field.required && field.type !== 'checkbox') {
+      if (field.required && field.type !== 'checkbox' && field.type !== 'file') {
         if (field.type === 'number') {
           validator = validator.min(1, { message: `${field.label} is required` });
-        } else if (field.type === 'file') {
-          validator = z.instanceof(File, { message: 'Please upload a file' });
         } else {
           validator = validator.min(1, { message: `${field.label} is required` });
         }
-      } else if (!field.required && field.type !== 'checkbox') {
+      } else if (!field.required && field.type !== 'checkbox' && field.type !== 'file') {
         validator = validator.optional();
       }
       


### PR DESCRIPTION
## Fixes Issue
Fixes #3 - Optional file fields incorrectly show as required in SDK

## Problem
The Mantlz SDK had conflicting validation logic where file fields were set as optional in the switch case but then overwritten as required in conditional logic below.

## Solution
- Moved file validation logic entirely into the switch case
- Excluded file fields from conditional validation blocks to prevent overwriting
- Preserved existing behavior for all other field types

## Code Changes
File validation now properly checks field.required status:
- Optional file fields: z.instanceof(File).optional()
- Required file fields: z.instanceof(File, { message })

## Result
- Optional file fields no longer show as required
- Forms with empty optional file fields can be submitted
- Required file fields still work as expected
- No regression on other field types

This is a bug fix that restores expected behavior without breaking changes.